### PR TITLE
Update pdf-viewer dependency from 2.8.2 to 3.2.0-beta1

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -53,7 +53,7 @@ dependencies {
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
     implementation 'com.google.android.material:material:1.2.0-alpha04'
     implementation 'com.google.code.gson:gson:1.7.2'
-    implementation 'com.github.barteksc:android-pdf-viewer:2.8.2'
+    implementation 'com.github.barteksc:android-pdf-viewer:3.2.0-beta.1'
     implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.3.1")
     //implementation 'com.mindorks.android:prdownloader:0.6.0' //for downloading pdfs from the internet
 }

--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,7 @@ allprojects {
     repositories {
         google()
         mavenCentral()
-        maven { url "http://jcenter.bintray.com" } //to replace jcenter
+        maven { url "https://jcenter.bintray.com" } //to replace jcenter
         //jcenter() // Warning: this repository is going to shut down soon
     }
 }


### PR DESCRIPTION
While I strongly suggest to switch  away from this stagnating library (last update is august 2019 https://github.com/barteksc/AndroidPdfViewer) here is a temporary fix.

Release 2.8.2 has disappeared from any repository. new dependency can be checked at https://mvnrepository.com/artifact/com.github.barteksc/android-pdf-viewer?repo=springio-libs-release